### PR TITLE
Add golden spiral style using golden ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Simple tool to generate abstract drawings in various styles.
 - **Style E:** Abstract Expressionism
 - **Style F:** Dot Spiral
 - **Style G:** Psychedelic Doodles
+- **Style H:** Golden Spiral (points follow the golden ratio)
 
 ## Usage
 
@@ -26,6 +27,7 @@ and adjust the values to change how many elements are drawn.
 | Style E | `strokes` |
 | Style F | `dots` |
 | Style G | `doodles` |
+| Style H | `segments` |
 
 Press **Generate** to render the selected styles in order. Use **Save** to
 export the image as a PNG file.

--- a/draw.py
+++ b/draw.py
@@ -28,6 +28,7 @@ class AbstractApp:
             "Style E": [("strokes", 30)],
             "Style F": [("dots", 150)],
             "Style G": [("doodles", 50)],
+            "Style H": [("segments", 40)],
         }
 
         for style, params in style_configs.items():
@@ -71,6 +72,8 @@ class AbstractApp:
                 self.draw_dot_spiral(**params)
             elif style == "Style G":
                 self.draw_psychedelic_doodles(**params)
+            elif style == "Style H":
+                self.draw_golden_spiral(**params)
 
         self.display_image()
 
@@ -148,6 +151,19 @@ class AbstractApp:
                 dx = random.randint(-radius, radius)
                 dy = random.randint(-radius, radius)
                 self.draw.line([(x, y), (x + dx, y + dy)], fill=color, width=2)
+
+    def draw_golden_spiral(self, segments=40):
+        phi = (1 + math.sqrt(5)) / 2
+        center = (WIDTH / 2, HEIGHT / 2)
+        angle = 0.0
+        radius = 5
+        for _ in range(segments):
+            x = center[0] + radius * math.cos(angle)
+            y = center[1] + radius * math.sin(angle)
+            color = tuple(random.choices(range(256), k=3))
+            self.draw.ellipse([x - 3, y - 3, x + 3, y + 3], fill=color)
+            angle += math.pi / 8  # small increment
+            radius *= phi ** (1 / 8)
 
     def display_image(self):
         self.tk_image = ImageTk.PhotoImage(self.image)


### PR DESCRIPTION
## Summary
- create new golden spiral drawing style that uses the golden ratio
- expose `segments` parameter for the new style
- document the golden spiral style in README

## Testing
- `python3 -m py_compile draw.py`

------
https://chatgpt.com/codex/tasks/task_e_6876affb3e4c832f90aa609ce0239f2a